### PR TITLE
Fix typo Burno Retailleau -> Bruno

### DIFF
--- a/platform/src/data/people/bretailleau/index.md
+++ b/platform/src/data/people/bretailleau/index.md
@@ -1,5 +1,5 @@
 ---
-name: "Burno Retailleau"
+name: "Bruno Retailleau"
 wiki: "https://fr.wikipedia.org/wiki/Bruno_Retailleau"
 photo: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/61/Bruno_Retailleau_-_Ministre_de_l%27Int%C3%A9rieur_fran%C3%A7ais_%28cropped%29.jpg/330px-Bruno_Retailleau_-_Ministre_de_l%27Int%C3%A9rieur_fran%C3%A7ais_%28cropped%29.jpg"
 group: "les-republicains"


### PR DESCRIPTION
According to its [wiki page](https://fr.wikipedia.org/wiki/Bruno_Retailleau), M. Retailleau seems to go by Bruno, not Burno. This should address the issue!